### PR TITLE
Revert to ES6

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "backend",
   "version": "1.0.0",
+  "type": "module",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,9 +1,9 @@
-const express = require('express');
-const cors = require('cors');
-require('dotenv').config();
+import express from 'express';
+import cors from 'cors';
+import 'dotenv/config';
 
-const jiraService = require('./services/jiraService');
-const { info, debug, error, warn } = require('./utils/logger');
+import * as jiraService from './services/jiraService.js';
+import { info, debug, error, warn } from './utils/logger.js';
 
 const app = express();
 const PORT = process.env.PORT || 3001;

--- a/backend/services/jiraService.js
+++ b/backend/services/jiraService.js
@@ -1,5 +1,5 @@
-const createFetcher = require('../utils/fetcher');
-const { debug, error, info, warn } = require('../utils/logger');
+import createFetcher from '../utils/fetcher.js';
+import { debug, error, info, warn } from '../utils/logger.js';
 
 let fetcher = null;
 let baseURL = null;

--- a/backend/utils/fetcher.js
+++ b/backend/utils/fetcher.js
@@ -1,4 +1,4 @@
-const { debug, error } = require('./logger');
+import { debug, error } from './logger.js';
 
 const createFetcher = (baseURL = '', defaultHeaders = {}) => {
   const headers = {
@@ -89,5 +89,5 @@ const createFetcher = (baseURL = '', defaultHeaders = {}) => {
   return { get, post, put, delete: del };
 };
 
-module.exports = createFetcher;
+export default createFetcher;
 

--- a/backend/utils/logger.js
+++ b/backend/utils/logger.js
@@ -57,4 +57,4 @@ const debug = (message, data = null) => {
   }
 };
 
-module.exports = { log, error, warn, info, debug };
+export { log, error, warn, info, debug };

--- a/frontend/.vite/deps/_metadata.json
+++ b/frontend/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "db1c05b6",
+  "configHash": "092889f3",
+  "lockfileHash": "d324151e",
+  "browserHash": "2fe99696",
+  "optimized": {},
+  "chunks": {}
+}

--- a/frontend/.vite/deps/package.json
+++ b/frontend/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
This pull request updates the backend Node.js codebase to use ECMAScript modules (ESM) instead of CommonJS. It replaces all require/module.exports statements with import/export syntax and adds "type": "module" to package.json. Additionally, it introduces some new Vite-generated metadata and package.json files in the frontend’s .vite/deps directory.